### PR TITLE
Published from Watson Studio.

### DIFF
--- a/jupyterTest_WatsonStudio_C2w3.ipynb
+++ b/jupyterTest_WatsonStudio_C2w3.ipynb
@@ -1,0 +1,54 @@
+{
+    "cells": [
+        {
+            "metadata": {},
+            "cell_type": "markdown",
+            "source": "# C2W3 - Jupyter Notebooks in Watson Studio\n\nThis video covers the basics for using Jupyter Notebooks in Watson Studio, such as \n* how to create a project, \n* adding a Notebook to the project, \n* creating a pandas DataFrame (SparkSession DataFrame for Scala kernels), \n* creating jobs (i.e. setting a fixed time for the Notebook to be run at), and \n* linking Watson Studio to GitHub.\n\nThis notebook utilises the file *netflix_titles.csv* from a Kaggle user."
+        },
+        {
+            "metadata": {},
+            "cell_type": "code",
+            "source": "import types\nimport pandas as pd\nfrom botocore.client import Config\nimport ibm_boto3\n\ndef __iter__(self): return 0\n\n# @hidden_cell\n# The following code accesses a file in your IBM Cloud Object Storage. It includes your credentials.\n# You might want to remove those credentials before you share the notebook.\nclient_b4f32cc2b17b439e8579c76a4cb3ad6c = ibm_boto3.client(service_name='s3',\n    ibm_api_key_id='xxxxxxxxxxxx',\n    ibm_auth_endpoint=\"xxxxxxx\",\n    config=Config(signature_version='oauth'),\n    endpoint_url='xxxxxxxxxxx')\n\nbody = client_b4f32cc2b17b439e8579c76a4cb3ad6c.get_object(Bucket='ibmdatasciencecourserac2w3jupyter-donotdelete-pr-ipsapaheiamtx1',Key='netflix_titles.csv')['Body']\n# add missing __iter__ method, so pandas accepts body as file-like object\nif not hasattr(body, \"__iter__\"): body.__iter__ = types.MethodType( __iter__, body )\n\ndf_data_1 = pd.read_csv(body)\ndf_data_1.head()\n",
+            "execution_count": 1,
+            "outputs": [
+                {
+                    "output_type": "execute_result",
+                    "execution_count": 1,
+                    "data": {
+                        "text/plain": "    show_id     type                                    title  \\\n0  81145628    Movie  Norm of the North: King Sized Adventure   \n1  80117401    Movie               Jandino: Whatever it Takes   \n2  70234439  TV Show                       Transformers Prime   \n3  80058654  TV Show         Transformers: Robots in Disguise   \n4  80125979    Movie                             #realityhigh   \n\n                   director  \\\n0  Richard Finn, Tim Maltby   \n1                       NaN   \n2                       NaN   \n3                       NaN   \n4          Fernando Lebrija   \n\n                                                cast  \\\n0  Alan Marriott, Andrew Toth, Brian Dobson, Cole...   \n1                                   Jandino Asporaat   \n2  Peter Cullen, Sumalee Montano, Frank Welker, J...   \n3  Will Friedle, Darren Criss, Constance Zimmer, ...   \n4  Nesta Cooper, Kate Walsh, John Michael Higgins...   \n\n                                    country         date_added  release_year  \\\n0  United States, India, South Korea, China  September 9, 2019          2019   \n1                            United Kingdom  September 9, 2016          2016   \n2                             United States  September 8, 2018          2013   \n3                             United States  September 8, 2018          2016   \n4                             United States  September 8, 2017          2017   \n\n     rating  duration                           listed_in  \\\n0     TV-PG    90 min  Children & Family Movies, Comedies   \n1     TV-MA    94 min                     Stand-Up Comedy   \n2  TV-Y7-FV  1 Season                            Kids' TV   \n3     TV-Y7  1 Season                            Kids' TV   \n4     TV-14    99 min                            Comedies   \n\n                                         description  \n0  Before planning an awesome wedding for his gra...  \n1  Jandino Asporaat riffs on the challenges of ra...  \n2  With the help of three human allies, the Autob...  \n3  When a prison ship crash unleashes hundreds of...  \n4  When nerdy high schooler Dani finally attracts...  ",
+                        "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>show_id</th>\n      <th>type</th>\n      <th>title</th>\n      <th>director</th>\n      <th>cast</th>\n      <th>country</th>\n      <th>date_added</th>\n      <th>release_year</th>\n      <th>rating</th>\n      <th>duration</th>\n      <th>listed_in</th>\n      <th>description</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>81145628</td>\n      <td>Movie</td>\n      <td>Norm of the North: King Sized Adventure</td>\n      <td>Richard Finn, Tim Maltby</td>\n      <td>Alan Marriott, Andrew Toth, Brian Dobson, Cole...</td>\n      <td>United States, India, South Korea, China</td>\n      <td>September 9, 2019</td>\n      <td>2019</td>\n      <td>TV-PG</td>\n      <td>90 min</td>\n      <td>Children &amp; Family Movies, Comedies</td>\n      <td>Before planning an awesome wedding for his gra...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>80117401</td>\n      <td>Movie</td>\n      <td>Jandino: Whatever it Takes</td>\n      <td>NaN</td>\n      <td>Jandino Asporaat</td>\n      <td>United Kingdom</td>\n      <td>September 9, 2016</td>\n      <td>2016</td>\n      <td>TV-MA</td>\n      <td>94 min</td>\n      <td>Stand-Up Comedy</td>\n      <td>Jandino Asporaat riffs on the challenges of ra...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>70234439</td>\n      <td>TV Show</td>\n      <td>Transformers Prime</td>\n      <td>NaN</td>\n      <td>Peter Cullen, Sumalee Montano, Frank Welker, J...</td>\n      <td>United States</td>\n      <td>September 8, 2018</td>\n      <td>2013</td>\n      <td>TV-Y7-FV</td>\n      <td>1 Season</td>\n      <td>Kids' TV</td>\n      <td>With the help of three human allies, the Autob...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>80058654</td>\n      <td>TV Show</td>\n      <td>Transformers: Robots in Disguise</td>\n      <td>NaN</td>\n      <td>Will Friedle, Darren Criss, Constance Zimmer, ...</td>\n      <td>United States</td>\n      <td>September 8, 2018</td>\n      <td>2016</td>\n      <td>TV-Y7</td>\n      <td>1 Season</td>\n      <td>Kids' TV</td>\n      <td>When a prison ship crash unleashes hundreds of...</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>80125979</td>\n      <td>Movie</td>\n      <td>#realityhigh</td>\n      <td>Fernando Lebrija</td>\n      <td>Nesta Cooper, Kate Walsh, John Michael Higgins...</td>\n      <td>United States</td>\n      <td>September 8, 2017</td>\n      <td>2017</td>\n      <td>TV-14</td>\n      <td>99 min</td>\n      <td>Comedies</td>\n      <td>When nerdy high schooler Dani finally attracts...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+                    },
+                    "metadata": {}
+                }
+            ]
+        },
+        {
+            "metadata": {},
+            "cell_type": "code",
+            "source": "",
+            "execution_count": null,
+            "outputs": []
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "name": "python3",
+            "display_name": "Python 3.7",
+            "language": "python"
+        },
+        "language_info": {
+            "name": "python",
+            "version": "3.7.9",
+            "mimetype": "text/x-python",
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "pygments_lexer": "ipython3",
+            "nbconvert_exporter": "python",
+            "file_extension": ".py"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 1
+}


### PR DESCRIPTION
There was an error ('An error occurred while publishing the notebook - Try again later') when I tried to publish my Jupyter Notebook from Watson Studio to GitHub. 

It turns out that this error occurred because Watson Studio had attempted to publish the notebook to ozervesh/IBMDataScience/_**master**_ although the base branch is actually named ozervesh/IBMDataScience/_**main**_.

The error was eliminated by creating a separate branch named 'master' before a pull request was created to merge 'master' and 'main'.